### PR TITLE
路人点击评价栏会跳转到登录页面

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,13 +10,14 @@ class ApplicationController < ActionController::Base
 
   private
   def not_authenticated
-    redirect_to new_session_path, :alert => "请先登录"
+    respond_to do |format|
+      format.html { redirect_to new_session_path, :alert => "请先登录"}
+      format.js {
+        flash[:alert] = "请先登录"
+        render body: "window.location = '/sessions/new'"}
+    end
+
   end
 
-  def require_login
-    respond_to do |format|
-      format.html(super)
-      format.js { render text: "window.location = '/sessions/new'" }
-    end
-  end
+
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,4 +13,10 @@ class ApplicationController < ActionController::Base
     redirect_to new_session_path, :alert => "请先登录"
   end
 
+  def require_login
+    respond_to do |format|
+      format.html(super)
+      format.js { render text: "window.location = '/sessions/new'" }
+    end
+  end
 end


### PR DESCRIPTION
-Override #require_login - #require_login is a method from socery 
- js request needed to be overrides when require_login is fale 
- Temporary solution: overide the require_login method,  redirect js authentication failure to js text script to /sessions/new